### PR TITLE
[ShaderToy] Support non-conformant Davinci Resolve

### DIFF
--- a/Shadertoy/Shadertoy.cpp
+++ b/Shadertoy/Shadertoy.cpp
@@ -1114,6 +1114,11 @@ ShadertoyPlugin::render(const RenderArguments &args)
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     openGLRender = args.openGLEnabled;
 
+    if (getImageEffectHostDescription()->hostName.compare(0, 14, "DaVinciResolve") == 0) {
+        // DaVinci Resolve advertises GL supported but doesn't enable it here :|
+        openGLRender = true;
+    }
+
     // do the rendering
     if (openGLRender) {
         return renderGL(args);


### PR DESCRIPTION
Resolve calls render() without doing any housekeeping in GL, so I jerry-rigged some code to upload/download textures before/after rendering.

It's slow, but it works! There should be no regressions on hosts that support GL already.