### PR TITLE
#60 - fix buffer overflow in DenoiseSharpen node

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,8 +84,8 @@ install:
   - cmd: "where patch"
 
   - git submodule -q update --init --recursive
-  - curl -L -s -S -o CImg/CImg.h https://raw.githubusercontent.com/dtschump/CImg/a841cc3080ee7bc00c5781e94b7f06c2920453ac/CImg.h
-  - curl -L -s -S -o CImg/Inpaint/inpaint.h https://raw.githubusercontent.com/dtschump/CImg/a841cc3080ee7bc00c5781e94b7f06c2920453ac/plugins/inpaint.h
+  - curl -L -s -S -o CImg/CImg.h https://raw.githubusercontent.com/dtschump/CImg/0c333883a9d16d007e2db6a1792c97aeb2021b51/CImg.h
+  - curl -L -s -S -o CImg/Inpaint/inpaint.h https://raw.githubusercontent.com/dtschump/CImg/0c333883a9d16d007e2db6a1792c97aeb2021b51/plugins/inpaint.h
   - patch -p0 -dCImg < CImg/Inpaint/inpaint.h.patch
 
 #---------------------------------#

--- a/CImg/CImgFilter.h
+++ b/CImg/CImgFilter.h
@@ -119,7 +119,11 @@
 #define cimg_namespace_suffix openfx_misc
 #ifdef _OPENMP
 #  ifndef cimg_use_openmp
-#    define cimg_use_openmp
+#    define cimg_use_openmp 1
+#  endif
+#else
+#  ifndef cimg_use_openmp
+#    define cimg_use_openmp 0
 #  endif
 #endif
 #define cimg_verbosity 0
@@ -179,7 +183,7 @@ struct tls
 inline void
 gImageEffectAbort()
 {
-#  ifdef cimg_use_openmp
+#  if cimg_use_openmp==1
     if ( omp_get_thread_num() ) {
         return;
     }
@@ -212,7 +216,7 @@ struct tls
 inline void
 gImageEffectAbort()
 {
-#  ifdef cimg_use_openmp
+#  if cimg_use_openmp==1
     if ( omp_get_thread_num() ) {
         return;
     }
@@ -754,7 +758,7 @@ CImgFilterPluginHelper<Params, sourceIsOptional>::render(const OFX::RenderArgume
     }
 #endif
 
-#ifdef cimg_use_openmp
+#if cimg_use_openmp==1
     // set the number of OpenMP threads to a reasonable value
     // (but remember that the OpenMP threads are not counted my the multithread suite)
     {

--- a/CImg/Denoise/CImgDenoise.cpp
+++ b/CImg/Denoise/CImgDenoise.cpp
@@ -67,7 +67,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kSupportsMultipleClipPARs false
 #define kSupportsMultipleClipDepths false
 #define kRenderThreadSafety eRenderFullySafe
-#ifdef cimg_use_openmp
+#if cimg_use_openmp==1
 #define kHostFrameThreading false
 #else
 #define kHostFrameThreading true
@@ -190,7 +190,7 @@ public:
 #undef _cimg_blur_patch2d
 
 #undef cimg_abort_test
-#ifdef cimg_use_openmp
+#if cimg_use_openmp==1
 #define cimg_abort_test if (!omp_get_thread_num() && abort()) throw CImgAbortException("")
 #else
 #define cimg_abort_test if (abort()) throw CImgAbortException("")

--- a/CImg/Makefile
+++ b/CImg/Makefile
@@ -146,7 +146,8 @@ endif
 # commit a841cc3080ee7bc00c5781e94b7f06c2920453ac is CImg 2.2.3+
 # commit 4d54d452896fdf9347af68d3854f98f4986eea4c is CImg 2.3.1
 # commit 548744b47c9316f656c4bdd1206e78646226c6be is CImg 2.3.3
-CIMGVERSION=548744b47c9316f656c4bdd1206e78646226c6be
+# commit 0c333883a9d16d007e2db6a1792c97aeb2021b51 is CImg 2.6.1+
+CIMGVERSION=0c333883a9d16d007e2db6a1792c97aeb2021b51
 
 CImg.h: Inpaint/inpaint.h
 	curl -L -s -S -o $@ https://raw.githubusercontent.com/dtschump/CImg/$(CIMGVERSION)/CImg.h

--- a/CImg/SharpenShock/CImgSharpenShock.cpp
+++ b/CImg/SharpenShock/CImgSharpenShock.cpp
@@ -99,7 +99,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kParamIterationsDefault 1
 
 #undef cimg_abort_test
-#ifdef cimg_use_openmp
+#if cimg_use_openmp==1
 #define cimg_abort_test if (!omp_get_thread_num() && abort()) throw CImgAbortException("")
 #else
 #define cimg_abort_test if (abort()) throw CImgAbortException("")

--- a/DenoiseSharpen/DenoiseSharpen.cpp
+++ b/DenoiseSharpen/DenoiseSharpen.cpp
@@ -2572,11 +2572,12 @@ DenoiseSharpenPlugin::renderForBitDepth(const RenderArguments &args)
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-    for (int y = procWindow.y1; y < procWindow.y2; y++) {
+    for (int y = p.srcWindow.y1; y < p.srcWindow.y2; y++) {
         abort_test_loop();
 
-        PIX *dstPix = (PIX *) dst->getPixelAddress(procWindow.x1, y);
-        for (int x = procWindow.x1; x < procWindow.x2; x++) {
+        // Note: we suppose that srcWindow is bound inside procWindow bound
+        PIX *dstPix = (PIX *) dst->getPixelAddress(procWindow.x1 + p.srcWindow.x1, procWindow.y1 + y);
+        for (int x = p.srcWindow.x1; x < p.srcWindow.x2; x++, dstPix += nComponents) {
             const PIX *srcPix = (const PIX *)  (src.get() ? src->getPixelAddress(x, y) : 0);
             unsigned int pix = (x - p.srcWindow.x1) + (y - p.srcWindow.y1) * iwidth;
             float tmpPix[4] = {0., 0., 0., 1.};
@@ -2647,8 +2648,6 @@ DenoiseSharpenPlugin::renderForBitDepth(const RenderArguments &args)
                     }
                 }
             }
-            // increment the dst pixel
-            dstPix += nComponents;
         }
     }
 } // DenoiseSharpenPlugin::renderForBitDepth


### PR DESCRIPTION
pixel offset computation are wrong in second image loop
during the rendering of the plugin.
This causes a negative pixel offest on a unsigned int value, so overflow.

This patch fixes the overflow, but the rendering for some zoom factor
is not correct, rendering some black area than the modified image.
This happen only when the srcWindow size is lower than the rendering
Window.
Note: in Natron master branch, these sizes are always the same,
hidding the problem of the rendering loop computation.

Signed-off-by: Guillaume Roguez <yomgui1@gmail.com>