### PR TITLE
Corrects Grade slider labelling to align with ColorCorrect

### DIFF
--- a/Grade/Grade.cpp
+++ b/Grade/Grade.cpp
@@ -120,11 +120,11 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kParamWhitePointHint "Set the color of the brightest pixels in the image."
 
 #define kParamBlack "black"
-#define kParamBlackLabel "Black"
+#define kParamBlackLabel "Lift"
 #define kParamBlackHint "Colors corresponding to the blackpoint are set to this value."
 
 #define kParamWhite "white"
-#define kParamWhiteLabel "White"
+#define kParamWhiteLabel "Gain"
 #define kParamWhiteHint "Colors corresponding to the whitepoint are set to this value."
 
 #define kParamMultiply "multiply"


### PR DESCRIPTION
This changes the "Black" and "White" labels of the `grade` node to "Gain" and "Lift" so that the naming scheme aligns with the ColorCorrect node.