### PR TITLE
Match Nuke's default for centerlineWidth

### DIFF
--- a/CheckerBoard/CheckerBoard.cpp
+++ b/CheckerBoard/CheckerBoard.cpp
@@ -718,7 +718,7 @@ CheckerBoardPluginFactory::describeInContext(ImageEffectDescriptor &desc,
         DoubleParamDescriptor* param = desc.defineDoubleParam(kParamCenterLineWidth);
         param->setLabel(kParamCenterLineWidthLabel);
         param->setHint(kParamCenterLineWidthHint);
-        param->setDefault(1);
+        param->setDefault(3);
         param->setRange(0., DBL_MAX);
         param->setDisplayRange(0, 10);
         param->setAnimates(true); // can animate


### PR DESCRIPTION
Natron's default is currently 1px, Nuke's is 3px.  Seeing as all the other values match Nuke it would make sense for this one to match it as well?