### PR TITLE
Add space between between literal and identifier

### DIFF
--- a/DebugProxy/DebugProxy.cpp
+++ b/DebugProxy/DebugProxy.cpp
@@ -286,11 +286,11 @@ static const char* help_string =
     "  Plugin cache in the host, or modify the date of the DebugProxy binary.\n"
 #if defined(__linux__)
     "  On Linux, this can be done using the following command:\n"
-    "  touch "OFX_PATH "DebugProxy.ofx.bundle/Contents/Linux-x86*/DebugProxy.ofx\n"
+    "  touch " OFX_PATH "DebugProxy.ofx.bundle/Contents/Linux-x86*/DebugProxy.ofx\n"
 #endif
 #if defined(__FreeBSD__)
     "  On FreeBSD, this can be done using the following command:\n"
-    "  touch "OFX_PATH "DebugProxy.ofx.bundle/Contents/FreeBSD-x86*/DebugProxy.ofx\n"
+    "  touch " OFX_PATH "DebugProxy.ofx.bundle/Contents/FreeBSD-x86*/DebugProxy.ofx\n"
 #endif
 #if defined(__APPLE__)
     "  On OS X, this can be done using the following command:\n"


### PR DESCRIPTION
This is needed in order to compile with Clang since C++11 requires a
space between literal and identifier, otherwise, Clang will give an
error.