### PR TITLE
Fix NOMINMAX compiler warnings on Windows.

### DIFF
--- a/FrameHold/FrameHold.cpp
+++ b/FrameHold/FrameHold.cpp
@@ -24,7 +24,9 @@
 #include <cmath>
 #include <stdio.h> // for snprintf & _snprintf
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #  if defined(_MSC_VER) && _MSC_VER < 1900
 #    define snprintf _snprintf

--- a/FrameRange/FrameRange.cpp
+++ b/FrameRange/FrameRange.cpp
@@ -26,7 +26,9 @@
 #include <cmath> // for std::floor, std::ceil
 #include <stdio.h> // for snprintf & _snprintf
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #  if defined(_MSC_VER) && _MSC_VER < 1900
 #    define snprintf _snprintf


### PR DESCRIPTION
Added #ifndef blocks to only define NOMINMAX if it isn't already defined. This fixes redefinition warnings and is consistent with similar code elsewhere in this repository.