### PR TITLE
Fix openmp build issue caused by upgrading from gcc 14.2.0 to 15.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build Ubuntu 22.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
         run: |
           make -j2 CONFIG=debug
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openfx-misc-build-ubuntu_22-release
           path: Bundle

--- a/DenoiseSharpen/DenoiseSharpen.cpp
+++ b/DenoiseSharpen/DenoiseSharpen.cpp
@@ -50,8 +50,8 @@
 //#define DEBUG_STDOUT // output debugging messages on stdout (for Resolve)
 
 #if defined(_OPENMP)
-#include <omp.h>
 #define _GLIBCXX_PARALLEL // enable libstdc++ parallel STL algorithm (eg nth_element, sort...)
+#include <omp.h>
 #else
 #define kUseMultithread // define to use the multithread suite
 #endif


### PR DESCRIPTION
In gcc 15.1.0 omp.h now includes a header file that depends on the _GLIBCXX_PARALLEL macro being defined if _OPENMP is defined. This change simply moves the _GLIBCXX_PARALLEL #define before the omp.h #include so that the code will build.

Updated Ubuntu runner and actions/upload-artifact versions